### PR TITLE
Change View menu to have Tools items bound dynamically from the Tools collection

### DIFF
--- a/Assets/StringResources.Designer.cs
+++ b/Assets/StringResources.Designer.cs
@@ -115,6 +115,15 @@ namespace WpfCalava.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Tools.
+        /// </summary>
+        public static string Tools {
+            get {
+                return ResourceManager.GetString("Tools", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _View.
         /// </summary>
         public static string View {

--- a/Assets/StringResources.resx
+++ b/Assets/StringResources.resx
@@ -135,6 +135,9 @@
   <data name="SaveLayout" xml:space="preserve">
     <value>_Save layout</value>
   </data>
+  <data name="Tools" xml:space="preserve">
+    <value>Tools</value>
+  </data>
   <data name="View" xml:space="preserve">
     <value>_View</value>
   </data>

--- a/ViewModels/Main/MainViewModel.cs
+++ b/ViewModels/Main/MainViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Specialized;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Globalization;
 using System.Linq;
@@ -47,26 +48,19 @@ namespace WpfCalava.ViewModels
         internal MainViewModel(IEventAggregator events,
             IWindowManager window,
             IApplication application,
-            WordCounterViewModel wordCounter)
+            [ImportMany] IEnumerable<ToolBase> tools)
         {
             if (events == null) throw new ArgumentNullException("events");
             if (window == null) throw new ArgumentNullException("window");
             if (application == null) throw new ArgumentNullException("application");
-            if (wordCounter == null) throw new ArgumentNullException("wordCounter");
+            if (tools == null) throw new ArgumentNullException("tools");
 
             _events = events;
             _window = window;
             _application = application;
 
-            // we expose this tool as a property as we want to bind the View menu
-            // to its IsVisible property. Otherwise adding it to the tools collection
-            // would be enough.
-            WordCounter = wordCounter;
 
-            Tools = new BindableCollection<ToolBase>
-            {
-                WordCounter
-            };
+            Tools = new BindableCollection<ToolBase>(tools);
 
             Documents = new BindableCollection<DocumentBase>();
             // @@hack for synching the documents collection

--- a/ViewModels/ToolBase.cs
+++ b/ViewModels/ToolBase.cs
@@ -14,6 +14,7 @@ namespace WpfCalava.ViewModels
     {
         private bool _bIsSelected;
         private bool _bIsVisible;
+        private string _sName;
 
         /// <summary>
         /// Gets or sets the icon source.
@@ -50,12 +51,24 @@ namespace WpfCalava.ViewModels
             }
         }
 
+        public string Name
+        {
+            get { return _sName; }
+            set
+            {
+                if (value.Equals(_sName)) return;
+                _sName = value;
+                NotifyOfPropertyChange(() => Name);
+            }
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ToolBase"/> class.
         /// </summary>
-        protected ToolBase()
+        protected ToolBase(string name)
         {
             _bIsVisible = true;
+            _sName = name;
         }
     }
 }

--- a/ViewModels/WordCounter/WordCounterViewModel.cs
+++ b/ViewModels/WordCounter/WordCounterViewModel.cs
@@ -9,6 +9,7 @@ namespace WpfCalava.ViewModels
     /// A dummy tool pane just to have something to play with.
     /// </summary>
     [Export(typeof(WordCounterViewModel))]
+    [Export(typeof(ToolBase))]
     [PartCreationPolicy(CreationPolicy.Shared)]
     public sealed class WordCounterViewModel : ToolBase
     {
@@ -50,6 +51,7 @@ namespace WpfCalava.ViewModels
 
         //[ImportingConstructor]
         public WordCounterViewModel()
+            : base(StringResources.WordCounter)
         {
             DisplayName = StringResources.WordCounter;
             IconSource = new BitmapImage(new Uri("pack://siteoforigin:,,,/Assets/Images/Notes.png"));

--- a/Views/MainView.xaml
+++ b/Views/MainView.xaml
@@ -34,9 +34,16 @@
                           Name="AddDocument"/>
             </MenuItem>
             <MenuItem Header="{Binding Path=Resources.View,Source={StaticResource LocalizedStrings}}">
-                <MenuItem Header="{Binding Path=Resources.WordCounter,Source={StaticResource LocalizedStrings}}" 
-                          IsChecked="{Binding Path=WordCounter.IsVisible,Mode=TwoWay}"
-                          IsCheckable="True"/>
+                <MenuItem Header="{Binding Path=Resources.Tools,Source={StaticResource LocalizedStrings}}"
+                          ItemsSource="{Binding Path=Tools}">
+                    <MenuItem.ItemContainerStyle>
+                        <Style TargetType="MenuItem">
+                            <Setter Property="Header" Value="{Binding Path=Name}"/>
+                            <Setter Property="IsCheckable" Value="True"/>
+                            <Setter Property="IsChecked" Value="{Binding Path=IsVisible}"/>
+                        </Style>
+                    </MenuItem.ItemContainerStyle>
+                </MenuItem>
                 <Separator/>
                 <MenuItem Header="{Binding Path=Resources.RestoreLayout,Source={StaticResource LocalizedStrings}}" 
                           Click="OnRestoreLayoutClick"/>


### PR DESCRIPTION
Thanks for publishing your code, without it I wouldn't have been able to figure out using AvalonDock with MVVM (I wish they had better docs).

Using this method to bind the tools removes the requirement to manually add each tool as a property to MainViewModel and to the View menu. All tools will be automatically imported by MEF, and bound to the Tools MenuItem.
